### PR TITLE
Feat: Add message tree

### DIFF
--- a/client/src/app/components/MessageTree.scss
+++ b/client/src/app/components/MessageTree.scss
@@ -4,6 +4,29 @@
 @import "../../scss/media-queries";
 @import "../../scss/mixins";
 
+.message-tree-title {
+  @include font-size(12px);
+
+  position: relative;
+  color: var(--header-color);
+  font-family: $inter;
+  font-weight: 500;
+  letter-spacing: 0.5px;
+
+  div {
+    position: absolute;
+    top: 0;
+
+    &.title-parents {
+      left: 0;
+    }
+
+    &.title-children {
+      transform: translateX(100%);
+    }
+  }
+}
+
 .tree {
   position: relative;
 

--- a/client/src/app/components/MessageTree.scss
+++ b/client/src/app/components/MessageTree.scss
@@ -1,28 +1,57 @@
+@import "../../scss/fonts";
+@import "../../scss/themes";
+@import "../../scss/variables";
+@import "../../scss/media-queries";
+@import "../../scss/mixins";
+
 .tree {
   position: relative;
+
+  .parent-title {
+    position: absolute;
+    top: -30px;
+    width: 100%;
+    color: white;
+  }
 
   .parent,
   .child,
   .root {
+    @include font-size(12px);
+
     display: flex;
     position: absolute;
     align-items: center;
     justify-content: center;
     overflow: hidden;
-    background-color: purple;
+    border-radius: 4px;
+    background-color: var(--message-tree-bg);
+    color: var(--expanded-color);
+    font-family: $ibm-plex-mono;
+    font-weight: 600;
     cursor: pointer;
+  }
+
+  .parent {
+    padding: 8px 16px;
   }
 
   .root {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+    background: rgba(0, 224, 202, 0.2);
+    color: $mint-green-7;
   }
 
   .edge {
     position: absolute;
+    z-index: -1;
     width: 100%;
     height: 100%;
-    z-index: -1;
+
+    line {
+      stroke: var(--message-tree-bg);
+    }
   }
 }

--- a/client/src/app/components/MessageTree.scss
+++ b/client/src/app/components/MessageTree.scss
@@ -17,11 +17,11 @@
     position: absolute;
     top: 0;
 
-    &.title-parents {
+    &.parents-title {
       left: 0;
     }
 
-    &.title-children {
+    &.children-title {
       transform: translateX(100%);
     }
   }
@@ -29,16 +29,16 @@
 
 .tree {
   position: relative;
+  opacity: 1;
 
-  .parent-title {
-    position: absolute;
-    top: -30px;
-    width: 100%;
-    color: white;
+  &.busy {
+    opacity: 0.5;
+    cursor: wait;
   }
 
   .parent,
   .child,
+  .item,
   .root {
     @include font-size(12px);
 
@@ -52,6 +52,7 @@
     color: var(--expanded-color);
     font-family: $ibm-plex-mono;
     font-weight: 600;
+    letter-spacing: 0.5px;
     cursor: pointer;
   }
 

--- a/client/src/app/components/MessageTree.scss
+++ b/client/src/app/components/MessageTree.scss
@@ -1,0 +1,28 @@
+.tree {
+  position: relative;
+
+  .parent,
+  .child,
+  .root {
+    display: flex;
+    position: absolute;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    background-color: purple;
+    cursor: pointer;
+  }
+
+  .root {
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  .edge {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+  }
+}

--- a/client/src/app/components/MessageTree.tsx
+++ b/client/src/app/components/MessageTree.tsx
@@ -115,13 +115,7 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
 
                 {/* Parents column */}
                 <div className="tree-parents">
-                    {/* <div className="parent-title row space-between">
-                        <div>
-                            <span>Parents</span></div>
-                        <div>
-                            <span>Children</span></div>
 
-                    </div> */}
                     {this.state.parents?.map(parent => (
                         <div
                             style={{
@@ -138,9 +132,8 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
                                 });
                             }}
                         >
-                            {this.state.config === DESKTOP_CONFIG
-                                ? (<React.Fragment>{parent.id.slice(0, 6)}...{parent.id.slice(-6)}</React.Fragment>)
-                                : (<React.Fragment>{parent.id.slice(0, 4)}...{parent.id.slice(-4)}</React.Fragment>)}
+                            {parent.id.slice(0, this.state.config === DESKTOP_CONFIG
+                                ? 6 : 4)}...{parent.id.slice(this.state.config === DESKTOP_CONFIG ? -6 : -4)}
                         </div>
                     ))}
                 </div>
@@ -153,13 +146,8 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
                         width: `${this.state.config.itemWidth}px`
                     }}
                 >
-                    {this.state.config === DESKTOP_CONFIG
-                        ? (<React.Fragment>
-                            {this.state.currentMessage.slice(0, 6)}...{this.state.currentMessage.slice(-6)}
-                        </React.Fragment>)
-                        : (<React.Fragment>
-                            {this.state.currentMessage.slice(0, 4)}...{this.state.currentMessage.slice(-4)}
-                        </React.Fragment>)}
+                    {this.state.currentMessage.slice(0, this.state.config === DESKTOP_CONFIG
+                        ? 6 : 4)}...{this.state.currentMessage.slice(this.state.config === DESKTOP_CONFIG ? -6 : -4)}
                 </div>
 
                 {/* Children column */}
@@ -181,10 +169,8 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
                                 });
                             }}
                         >
-                            {this.state.config === DESKTOP_CONFIG
-                                ? (<React.Fragment>{child.id.slice(0, 6)}...{child.id.slice(-6)}</React.Fragment>)
-                                : (<React.Fragment>{child.id.slice(0, 4)}...{child.id.slice(-4)}</React.Fragment>)}
-
+                            {child.id.slice(0, this.state.config === DESKTOP_CONFIG
+                                ? 6 : 4)}...{child.id.slice(this.state.config === DESKTOP_CONFIG ? -6 : -4)}
                         </div>
                     ))}
                 </div>

--- a/client/src/app/components/MessageTree.tsx
+++ b/client/src/app/components/MessageTree.tsx
@@ -82,6 +82,13 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
                 }, () => {
                     this.loadItemsUI();
                 });
+            const top = document?.getElementById("messages-tree")?.offsetTop ?? 0;
+            const OFFSET = 200;
+            window.scrollTo({
+                left: 0,
+                top: top - OFFSET,
+                behavior: "smooth"
+            });
         }
     }
 
@@ -97,6 +104,7 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
     public render(): ReactNode {
         return (
             <div
+                id="messages-tree"
                 className="tree"
                 style={{
                     height: `${this.state.height}px`,

--- a/client/src/app/components/MessageTree.tsx
+++ b/client/src/app/components/MessageTree.tsx
@@ -103,93 +103,113 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
      */
     public render(): ReactNode {
         return (
-            <div
-                id="messages-tree"
-                className="tree"
-                style={{
-                    height: `${this.state.height}px`,
-                    width: `${this.state.width}px`
-                }}
-            >
-
-                {/* Parents column */}
-                <div className="tree-parents">
-
-                    {this.state.parents?.map(parent => (
-                        <div
-                            style={{
-                                height: `${this.state.config.itemHeight}px`,
-                                width: `${this.state.config.itemWidth}px`,
-                                left: 0,
-                                top: `${parent.top}px`
-                            }}
-                            className="parent"
-                            key={parent.id}
-                            onClick={() => {
-                                this.setState({ currentMessage: parent.id }, () => {
-                                    this.props.onSelected(parent.id, true);
-                                });
-                            }}
-                        >
-                            {parent.id.slice(0, this.state.config === DESKTOP_CONFIG
-                                ? 6 : 4)}...{parent.id.slice(this.state.config === DESKTOP_CONFIG ? -6 : -4)}
-                        </div>
-                    ))}
-                </div>
-
-                {/* Root */}
+            <React.Fragment>
                 <div
-                    className="root"
+                    className="message-tree-title row margin-b-m"
                     style={{
-                        height: `${this.state.config.itemHeight}px`,
-                        width: `${this.state.config.itemWidth}px`
+                        width: `${this.state.width}px`
                     }}
                 >
-                    {this.state.currentMessage.slice(0, this.state.config === DESKTOP_CONFIG
-                        ? 6 : 4)}...{this.state.currentMessage.slice(this.state.config === DESKTOP_CONFIG ? -6 : -4)}
+                    <div className="title-parents">Parents</div>
+                    <div
+                        className="title-children"
+                        style={{
+                            right: `${this.state.config.itemWidth}px`
+                        }}
+                    >
+                        Children
+                    </div>
+
                 </div>
+                <div
+                    id="messages-tree"
+                    className="tree"
+                    style={{
+                        height: `${this.state.height}px`,
+                        width: `${this.state.width}px`
+                    }}
+                >
 
-                {/* Children column */}
-                <div className="tree-children">
+                    {/* Parents column */}
+                    <div className="tree-parents">
 
-                    {this.state.children?.map(child => (
-                        <div
-                            style={{
-                                height: `${this.state.config.itemHeight}px`,
-                                width: `${this.state.config.itemWidth}px`,
-                                right: 0,
-                                top: `${child.top}px`
-                            }}
-                            className="child"
-                            key={child.id}
-                            onClick={() => {
-                                this.setState({ currentMessage: child.id }, () => {
-                                    this.props.onSelected(child.id, true);
-                                });
-                            }}
-                        >
-                            {child.id.slice(0, this.state.config === DESKTOP_CONFIG
-                                ? 6 : 4)}...{child.id.slice(this.state.config === DESKTOP_CONFIG ? -6 : -4)}
-                        </div>
-                    ))}
+                        {this.state.parents?.map(parent => (
+                            <div
+                                style={{
+                                    height: `${this.state.config.itemHeight}px`,
+                                    width: `${this.state.config.itemWidth}px`,
+                                    left: 0,
+                                    top: `${parent.top}px`
+                                }}
+                                className="parent"
+                                key={parent.id}
+                                onClick={() => {
+                                    this.setState({ currentMessage: parent.id }, () => {
+                                        this.props.onSelected(parent.id, true);
+                                    });
+                                }}
+                            >
+                                {parent.id.slice(0, this.state.config === DESKTOP_CONFIG
+                                    ? 6 : 4)}...{parent.id.slice(this.state.config === DESKTOP_CONFIG ? -6 : -4)}
+                            </div>
+                        ))}
+                    </div>
+
+                    {/* Root */}
+                    <div
+                        className="root"
+                        style={{
+                            height: `${this.state.config.itemHeight}px`,
+                            width: `${this.state.config.itemWidth}px`
+                        }}
+                    >
+                        {this.state.currentMessage.slice(0, this.state.config === DESKTOP_CONFIG
+                            ? 6 : 4)}...{this.state.currentMessage.slice(this.state.config === DESKTOP_CONFIG
+                                ? -6 : -4)}
+                    </div>
+
+                    {/* Children column */}
+                    <div className="tree-children">
+
+                        {this.state.children?.map(child => (
+                            <div
+                                style={{
+                                    height: `${this.state.config.itemHeight}px`,
+                                    width: `${this.state.config.itemWidth}px`,
+                                    right: 0,
+                                    top: `${child.top}px`
+                                }}
+                                className="child"
+                                key={child.id}
+                                onClick={() => {
+                                    this.setState({ currentMessage: child.id }, () => {
+                                        this.props.onSelected(child.id, true);
+                                    });
+                                }}
+                            >
+                                {child.id.slice(0, this.state.config === DESKTOP_CONFIG
+                                    ? 6 : 4)}...{child.id.slice(this.state.config === DESKTOP_CONFIG ? -6 : -4)}
+                            </div>
+                        ))}
+                    </div>
+
+                    {/* Edges */}
+                    <svg className="edge">
+                        {this.state.edges?.map(edge =>
+                        (
+                            <line
+                                key={edge.id}
+                                x1={edge.x1}
+                                x2={edge.x2}
+                                y1={edge.y1}
+                                y2={edge.y2}
+                                stroke="black"
+                            />
+                        )
+                        )}
+                    </svg>
                 </div>
-
-                {/* Edges */}
-                <svg className="edge">
-                    {this.state.edges?.map(edge =>
-                    (
-                        <line
-                            key={edge.id}
-                            x1={edge.x1}
-                            x2={edge.x2}
-                            y1={edge.y1}
-                            y2={edge.y2}
-                            stroke="black"
-                        />
-                    )
-                    )}
-                </svg>
-            </div>
+            </React.Fragment>
         );
     }
 

--- a/client/src/app/components/MessageTree.tsx
+++ b/client/src/app/components/MessageTree.tsx
@@ -90,6 +90,7 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
                 behavior: "smooth"
             });
         }
+        console.log("parents", this.state.parents);
     }
 
     public async componentWillUnmount(): Promise<void> {
@@ -114,6 +115,13 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
 
                 {/* Parents column */}
                 <div className="tree-parents">
+                    {/* <div className="parent-title row space-between">
+                        <div>
+                            <span>Parents</span></div>
+                        <div>
+                            <span>Children</span></div>
+
+                    </div> */}
                     {this.state.parents?.map(parent => (
                         <div
                             style={{
@@ -130,7 +138,9 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
                                 });
                             }}
                         >
-                            {parent.id.slice(0, 6)}...{parent.id.slice(-6)}
+                            {this.state.config === DESKTOP_CONFIG
+                                ? (<React.Fragment>{parent.id.slice(0, 6)}...{parent.id.slice(-6)}</React.Fragment>)
+                                : (<React.Fragment>{parent.id.slice(0, 4)}...{parent.id.slice(-4)}</React.Fragment>)}
                         </div>
                     ))}
                 </div>
@@ -143,11 +153,18 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
                         width: `${this.state.config.itemWidth}px`
                     }}
                 >
-                    {this.state.currentMessage.slice(0, 6)}...{this.state.currentMessage.slice(-6)}
+                    {this.state.config === DESKTOP_CONFIG
+                        ? (<React.Fragment>
+                            {this.state.currentMessage.slice(0, 6)}...{this.state.currentMessage.slice(-6)}
+                        </React.Fragment>)
+                        : (<React.Fragment>
+                            {this.state.currentMessage.slice(0, 4)}...{this.state.currentMessage.slice(-4)}
+                        </React.Fragment>)}
                 </div>
 
                 {/* Children column */}
                 <div className="tree-children">
+
                     {this.state.children?.map(child => (
                         <div
                             style={{
@@ -164,7 +181,10 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
                                 });
                             }}
                         >
-                            {child.id.slice(0, 6)}...{child.id.slice(-6)}
+                            {this.state.config === DESKTOP_CONFIG
+                                ? (<React.Fragment>{child.id.slice(0, 6)}...{child.id.slice(-6)}</React.Fragment>)
+                                : (<React.Fragment>{child.id.slice(0, 4)}...{child.id.slice(-4)}</React.Fragment>)}
+
                         </div>
                     ))}
                 </div>

--- a/client/src/app/components/MessageTree.tsx
+++ b/client/src/app/components/MessageTree.tsx
@@ -1,0 +1,197 @@
+import React, { Component, ReactNode } from "react";
+import "./MessageTree.scss";
+import { MessageTreeProps } from "./MessageTreeProps";
+import { MessageTreeState } from "./MessageTreeState";
+
+interface ItemUI {
+    top: number;
+    id: string;
+}
+interface EdgeUI {
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
+}
+/**
+ * Component which will show the visualizer page.
+ */
+class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
+    /**
+     * Message tree width.
+     */
+    private readonly _width: number;
+
+    /**
+     * Message tree item width.
+     */
+    private readonly _itemWidth: number = 144;
+
+    /**
+     * Horizontal space between columns.
+     */
+    private readonly _horizontalSpace: number = 80;
+
+    /**
+     * Height of each item.
+     */
+    private readonly _itemHeight: number = 32;
+
+    /**
+     * Vertical space between items.
+     */
+    private readonly _verticalSpace: number = 10;
+
+    /**
+     * Create a new instance of MessageTree.
+     * @param props The props.
+     */
+    constructor(props: MessageTreeProps) {
+        super(props);
+        this._width = (this._itemWidth * 3) + (this._horizontalSpace * 2);
+    }
+
+
+    /**
+     * The component mounted.
+     */
+    public async componentDidMount(): Promise<void> {
+        window.scrollTo({
+            left: 0,
+            top: 0,
+            behavior: "smooth"
+        });
+    }
+
+    /**
+     * Render the component.
+     * @returns The node to render.
+     */
+    public render(): ReactNode {
+        const [parents, children, edges] = this.getItemsUI();
+        const height: number = (Math.max(this.props.parentsIds.length, this.props.childrenIds.length) *
+            (this._itemHeight + this._verticalSpace)) -
+            this._verticalSpace;
+        return (
+            <div
+                className="tree"
+                style={{
+                    height: `${height}px`,
+                    width: `${this._width}px`
+                }}
+            >
+
+                {/* Parents column */}
+                <div className="tree-parents">
+                    {parents.map(parent => (
+                        <div
+                            style={{
+                                height: `${this._itemHeight}px`,
+                                width: `${this._itemWidth}px`,
+                                left: 0,
+                                top: `${parent.top}px`
+                            }}
+                            className="parent"
+                            key={parent.id}
+                            onClick={() => {
+                                this.props.onSelected(parent.id, true);
+                            }}
+                        >
+                            {parent.id.slice(0, 6)}...{parent.id.slice(-6)}
+                        </div>
+                    ))}
+                </div>
+
+                {/* Root */}
+                <div
+                    className="root"
+                    style={{
+                        height: `${this._itemHeight}px`,
+                        width: `${this._itemWidth}px`
+                    }}
+                >
+                    {this.props.messageId.slice(0, 6)}...{this.props.messageId.slice(-6)}
+                </div>
+
+                {/* Children column */}
+                <div className="tree-children">
+                    {children.map(child => (
+                        <div
+                            style={{
+                                height: `${this._itemHeight}px`,
+                                width: `${this._itemWidth}px`,
+                                right: 0,
+                                top: `${child.top}px`
+                            }}
+                            className="child"
+                            key={child.id}
+                            onClick={() => {
+                                this.props.onSelected(child.id, true);
+                            }}
+                        >
+                            {child.id.slice(0, 6)}...{child.id.slice(-6)}
+                        </div>
+                    ))}
+                </div>
+
+                {/* Edges */}
+                <svg className="edge">
+                    {edges.map(edge => (
+                        <line
+                            key={edge.x1}
+                            x1={edge.x1}
+                            x2={edge.x2}
+                            y1={edge.y1}
+                            y2={edge.y2}
+                            stroke="black"
+                        />
+                    ))}
+                </svg>
+            </div>
+        );
+    }
+
+
+    private getItemsUI(): [ItemUI[], ItemUI[], EdgeUI[]] {
+        const parentsHeight = ((this._itemHeight + this._verticalSpace) * this.props.parentsIds.length) -
+            this._verticalSpace;
+        const childrenHeight = ((this._itemHeight + this._verticalSpace) * this.props.childrenIds.length) -
+            this._verticalSpace;
+        const parentsOffsetTop = childrenHeight > parentsHeight ? (childrenHeight - parentsHeight) / 2 : 0;
+        const childrenOffsetTop = parentsHeight > childrenHeight ? (parentsHeight - childrenHeight) / 2 : 0;
+
+        const parents: ItemUI[] = this.props.parentsIds.map((parent, i) => (
+            {
+                top: ((this._itemHeight + this._verticalSpace) * i) + parentsOffsetTop,
+                id: parent
+            }
+        ));
+
+        const children: ItemUI[] = this.props.childrenIds.map((child, i) => ({
+            top: ((this._itemHeight + this._verticalSpace) * i) + childrenOffsetTop,
+            id: child
+        }));
+
+        const parentsLinks: EdgeUI[] = parents.map((parent, i) =>
+        ({
+            x1: this._itemWidth,
+            x2: (this._width - this._itemWidth) * 0.5,
+            y1: parent.top + (this._itemHeight * 0.5),
+            y2: Math.max(parentsHeight, childrenHeight) * 0.5
+        }
+        ));
+        const childrenLinks: EdgeUI[] = children.map((child, i) => (
+            {
+                x1: this._width - this._itemWidth,
+                x2: (this._width + this._itemWidth) * 0.5,
+                y1: child.top + (this._itemHeight * 0.5),
+                y2: Math.max(parentsHeight, childrenHeight) * 0.5
+            }
+        ));
+
+        const edges: EdgeUI[] = parentsLinks.concat(childrenLinks);
+        return [parents, children, edges];
+    }
+}
+
+export default MessageTree;

--- a/client/src/app/components/MessageTree.tsx
+++ b/client/src/app/components/MessageTree.tsx
@@ -48,7 +48,7 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
     /**
      * The component mounted.
      */
-    public async componentDidMount(): Promise<void> {
+    public componentDidMount(): void {
         window.scrollTo({
             left: 0,
             top: 0,
@@ -224,26 +224,15 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
 
         const items: ItemUI[] = parents.concat(children);
 
-        const parentsLinks: EdgeUI[] = parents.map((parent, i) =>
+        const edges: EdgeUI[] = items.map((item, i) =>
         ({
-            id: `edge--parent-${parent.id}`,
-            x1: this.state.config.itemWidth,
-            x2: ((this.state.width) - this.state.config.itemWidth) * 0.5,
-            y1: parent.top + (this.state.config.itemHeight * 0.5),
+            id: `edge--${item.type}-${item.id}`,
+            x1: item.type === "parent" ? this.state.config.itemWidth : (this.state.width) - this.state.config.itemWidth,
+            x2: ((this.state.width) - (this.state.config.itemWidth * (item.type === "parent" ? 1 : -1))) * 0.5,
+            y1: item.top + (this.state.config.itemHeight * 0.5),
             y2: Math.max(parentsHeight, childrenHeight) * 0.5
         }
         ));
-        const childrenLinks: EdgeUI[] = children.map((child, i) => (
-            {
-                id: `edge--child-${child.id}`,
-                x1: (this.state.width) - this.state.config.itemWidth,
-                x2: ((this.state.width) + this.state.config.itemWidth) * 0.5,
-                y1: child.top + (this.state.config.itemHeight * 0.5),
-                y2: Math.max(parentsHeight, childrenHeight) * 0.5
-            }
-        ));
-
-        const edges: EdgeUI[] = parentsLinks.concat(childrenLinks);
         this.setState({ items, edges });
     }
 }

--- a/client/src/app/components/MessageTree.tsx
+++ b/client/src/app/components/MessageTree.tsx
@@ -90,7 +90,6 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
                 behavior: "smooth"
             });
         }
-        console.log("parents", this.state.parents);
     }
 
     public async componentWillUnmount(): Promise<void> {

--- a/client/src/app/components/MessageTree.tsx
+++ b/client/src/app/components/MessageTree.tsx
@@ -1,56 +1,48 @@
 import React, { Component, ReactNode } from "react";
 import "./MessageTree.scss";
 import { MessageTreeProps } from "./MessageTreeProps";
-import { MessageTreeState } from "./MessageTreeState";
+import { EdgeUI, ItemUI, MessageTreeState } from "./MessageTreeState";
 
-interface ItemUI {
-    top: number;
-    id: string;
+
+interface TreeConfig {
+    verticalSpace: number;
+    horizontalSpace: number;
+    itemWidth: number;
+    itemHeight: number;
+    width?: number;
+    height?: number;
 }
-interface EdgeUI {
-    x1: number;
-    y1: number;
-    x2: number;
-    y2: number;
-}
+
+const DESKTOP_CONFIG: TreeConfig = {
+    verticalSpace: 20,
+    horizontalSpace: 80,
+    itemHeight: 32,
+    itemWidth: 144
+};
+const MOBILE_CONFIG: TreeConfig = {
+    verticalSpace: 18,
+    horizontalSpace: 16,
+    itemHeight: 24,
+    itemWidth: 98
+};
 /**
  * Component which will show the visualizer page.
  */
 class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
-    /**
-     * Message tree width.
-     */
-    private readonly _width: number;
-
-    /**
-     * Message tree item width.
-     */
-    private readonly _itemWidth: number = 144;
-
-    /**
-     * Horizontal space between columns.
-     */
-    private readonly _horizontalSpace: number = 80;
-
-    /**
-     * Height of each item.
-     */
-    private readonly _itemHeight: number = 32;
-
-    /**
-     * Vertical space between items.
-     */
-    private readonly _verticalSpace: number = 10;
-
     /**
      * Create a new instance of MessageTree.
      * @param props The props.
      */
     constructor(props: MessageTreeProps) {
         super(props);
-        this._width = (this._itemWidth * 3) + (this._horizontalSpace * 2);
+        this.state = {
+            isMobile: false,
+            children: [],
+            parents: [],
+            edges: [],
+            currentMessage: this.props.messageId
+        };
     }
-
 
     /**
      * The component mounted.
@@ -61,6 +53,30 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
             top: 0,
             behavior: "smooth"
         });
+        window.addEventListener("resize", this.resize.bind(this));
+        this.resize();
+        this.loadItemsUI();
+    }
+
+
+    public resize() {
+        const isMobile = window.innerWidth < 768;
+        if (isMobile !== this.state.isMobile) {
+            this.setState({ isMobile }, () => {
+                this.loadItemsUI();
+            });
+        }
+    }
+
+    public async componentDidUpdate(prevProps: MessageTreeProps): Promise<void> {
+        if (prevProps.parentsIds !== this.props.parentsIds) {
+            this.loadItemsUI();
+        }
+    }
+
+    public async componentWillUnmount(): Promise<void> {
+        // eslint-disable-next-line unicorn/no-invalid-remove-event-listener
+        window.removeEventListener("resize", this.resize.bind(this));
     }
 
     /**
@@ -68,33 +84,33 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
      * @returns The node to render.
      */
     public render(): ReactNode {
-        const [parents, children, edges] = this.getItemsUI();
-        const height: number = (Math.max(this.props.parentsIds.length, this.props.childrenIds.length) *
-            (this._itemHeight + this._verticalSpace)) -
-            this._verticalSpace;
+        const config = this.state.isMobile ? MOBILE_CONFIG : DESKTOP_CONFIG;
+
         return (
             <div
                 className="tree"
                 style={{
-                    height: `${height}px`,
-                    width: `${this._width}px`
+                    height: `${config.height}px`,
+                    width: `${config.width}px`
                 }}
             >
 
                 {/* Parents column */}
                 <div className="tree-parents">
-                    {parents.map(parent => (
+                    {this.state.parents?.map(parent => (
                         <div
                             style={{
-                                height: `${this._itemHeight}px`,
-                                width: `${this._itemWidth}px`,
+                                height: `${config.itemHeight}px`,
+                                width: `${config.itemWidth}px`,
                                 left: 0,
                                 top: `${parent.top}px`
                             }}
                             className="parent"
                             key={parent.id}
                             onClick={() => {
-                                this.props.onSelected(parent.id, true);
+                                this.setState({ currentMessage: parent.id }, () => {
+                                    this.props.onSelected(parent.id, true);
+                                });
                             }}
                         >
                             {parent.id.slice(0, 6)}...{parent.id.slice(-6)}
@@ -106,27 +122,29 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
                 <div
                     className="root"
                     style={{
-                        height: `${this._itemHeight}px`,
-                        width: `${this._itemWidth}px`
+                        height: `${config.itemHeight}px`,
+                        width: `${config.itemWidth}px`
                     }}
                 >
-                    {this.props.messageId.slice(0, 6)}...{this.props.messageId.slice(-6)}
+                    {this.state.currentMessage.slice(0, 6)}...{this.state.currentMessage.slice(-6)}
                 </div>
 
                 {/* Children column */}
                 <div className="tree-children">
-                    {children.map(child => (
+                    {this.state.children?.map(child => (
                         <div
                             style={{
-                                height: `${this._itemHeight}px`,
-                                width: `${this._itemWidth}px`,
+                                height: `${config.itemHeight}px`,
+                                width: `${config.itemWidth}px`,
                                 right: 0,
                                 top: `${child.top}px`
                             }}
                             className="child"
                             key={child.id}
                             onClick={() => {
-                                this.props.onSelected(child.id, true);
+                                this.setState({ currentMessage: child.id }, () => {
+                                    this.props.onSelected(child.id, true);
+                                });
                             }}
                         >
                             {child.id.slice(0, 6)}...{child.id.slice(-6)}
@@ -136,61 +154,74 @@ class MessageTree extends Component<MessageTreeProps, MessageTreeState> {
 
                 {/* Edges */}
                 <svg className="edge">
-                    {edges.map(edge => (
+                    {this.state.edges?.map(edge =>
+                    (
                         <line
-                            key={edge.x1}
+                            key={edge.id}
                             x1={edge.x1}
                             x2={edge.x2}
                             y1={edge.y1}
                             y2={edge.y2}
                             stroke="black"
                         />
-                    ))}
+                    )
+                    )}
                 </svg>
             </div>
         );
     }
 
 
-    private getItemsUI(): [ItemUI[], ItemUI[], EdgeUI[]] {
-        const parentsHeight = ((this._itemHeight + this._verticalSpace) * this.props.parentsIds.length) -
-            this._verticalSpace;
-        const childrenHeight = ((this._itemHeight + this._verticalSpace) * this.props.childrenIds.length) -
-            this._verticalSpace;
+    private loadItemsUI(): void {
+        const config = this.state.isMobile ? MOBILE_CONFIG : DESKTOP_CONFIG;
+        const width: number = (config.itemWidth * 3) + (config.horizontalSpace * 2);
+        const height: number = (Math.max(this.props.parentsIds.length, this.props.childrenIds.length) *
+            (config.itemHeight + config.verticalSpace)) -
+            config.verticalSpace;
+        config.width = width;
+        config.height = height;
+        const parentsHeight = ((config.itemHeight + config.verticalSpace) * this.props.parentsIds.length) -
+            config.verticalSpace;
+        const childrenHeight = ((config.itemHeight + config.verticalSpace) * this.props.childrenIds.length) -
+            config.verticalSpace;
         const parentsOffsetTop = childrenHeight > parentsHeight ? (childrenHeight - parentsHeight) / 2 : 0;
         const childrenOffsetTop = parentsHeight > childrenHeight ? (parentsHeight - childrenHeight) / 2 : 0;
 
         const parents: ItemUI[] = this.props.parentsIds.map((parent, i) => (
             {
-                top: ((this._itemHeight + this._verticalSpace) * i) + parentsOffsetTop,
+                top: ((config.itemHeight + config.verticalSpace) * i) + parentsOffsetTop,
+                left: 0,
                 id: parent
             }
         ));
 
         const children: ItemUI[] = this.props.childrenIds.map((child, i) => ({
-            top: ((this._itemHeight + this._verticalSpace) * i) + childrenOffsetTop,
+            top: ((config.itemHeight + config.verticalSpace) * i) + childrenOffsetTop,
+            right: 0,
             id: child
         }));
 
         const parentsLinks: EdgeUI[] = parents.map((parent, i) =>
         ({
-            x1: this._itemWidth,
-            x2: (this._width - this._itemWidth) * 0.5,
-            y1: parent.top + (this._itemHeight * 0.5),
+            id: `edge--parent-${parent.id}`,
+            x1: config.itemWidth,
+            x2: (width - config.itemWidth) * 0.5,
+            y1: parent.top + (config.itemHeight * 0.5),
             y2: Math.max(parentsHeight, childrenHeight) * 0.5
         }
         ));
         const childrenLinks: EdgeUI[] = children.map((child, i) => (
             {
-                x1: this._width - this._itemWidth,
-                x2: (this._width + this._itemWidth) * 0.5,
-                y1: child.top + (this._itemHeight * 0.5),
+                id: `edge--child-${child.id}`,
+                x1: width - config.itemWidth,
+                x2: (width + config.itemWidth) * 0.5,
+                y1: child.top + (config.itemHeight * 0.5),
                 y2: Math.max(parentsHeight, childrenHeight) * 0.5
             }
         ));
 
         const edges: EdgeUI[] = parentsLinks.concat(childrenLinks);
-        return [parents, children, edges];
+        this.setState({ parents, children, edges });
     }
 }
 

--- a/client/src/app/components/MessageTreeProps.tsx
+++ b/client/src/app/components/MessageTreeProps.tsx
@@ -1,0 +1,7 @@
+
+export interface MessageTreeProps {
+    parentsIds: string[];
+    childrenIds: string[];
+    messageId: string;
+    onSelected: (messageId: string, updateUrl: boolean) => void;
+}

--- a/client/src/app/components/MessageTreeState.tsx
+++ b/client/src/app/components/MessageTreeState.tsx
@@ -1,0 +1,6 @@
+export interface MessageTreeState {
+    /**
+     * Tree height in px.
+     */
+    height: number;
+}

--- a/client/src/app/components/MessageTreeState.tsx
+++ b/client/src/app/components/MessageTreeState.tsx
@@ -1,6 +1,39 @@
+export interface ItemUI {
+    top: number;
+    left?: number;
+    right?: number;
+    id: string;
+}
+export interface EdgeUI {
+    id: string;
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
+}
 export interface MessageTreeState {
     /**
-     * Tree height in px.
+     * Is mobile
      */
-    height: number;
+    isMobile: boolean;
+
+    /**
+     * Edges
+     */
+    edges?: EdgeUI[];
+
+    /**
+     * Parents UI
+     */
+    parents?: ItemUI[];
+
+    /**
+     * Children UI
+     */
+    children?: ItemUI[];
+
+    /**
+     * Current message
+     */
+    currentMessage: string;
 }

--- a/client/src/app/components/MessageTreeState.tsx
+++ b/client/src/app/components/MessageTreeState.tsx
@@ -1,8 +1,7 @@
 export interface ItemUI {
     top: number;
-    left?: number;
-    right?: number;
     id: string;
+    type: "child" | "parent";
 }
 export interface EdgeUI {
     id: string;
@@ -39,17 +38,17 @@ export interface MessageTreeState {
     edges?: EdgeUI[];
 
     /**
-     * Parents UI
+     * Parents and children
      */
-    parents?: ItemUI[];
-
-    /**
-     * Children UI
-     */
-    children?: ItemUI[];
+    items?: ItemUI[];
 
     /**
      * Current message
      */
     currentMessage: string;
+
+    /**
+     * If tree is loading
+     */
+    isBusy: boolean;
 }

--- a/client/src/app/components/MessageTreeState.tsx
+++ b/client/src/app/components/MessageTreeState.tsx
@@ -11,11 +11,27 @@ export interface EdgeUI {
     x2: number;
     y2: number;
 }
+export interface TreeConfig {
+    verticalSpace: number;
+    horizontalSpace: number;
+    itemWidth: number;
+    itemHeight: number;
+}
 export interface MessageTreeState {
     /**
-     * Is mobile
+     * UI Tree configuration
      */
-    isMobile: boolean;
+    config: TreeConfig;
+
+    /**
+     * UI Tree configuration
+     */
+    width: number;
+
+    /**
+     * UI Tree configuration
+     */
+    height: number;
 
     /**
      * Edges

--- a/client/src/app/components/chrysalis/IndexationPayload.tsx
+++ b/client/src/app/components/chrysalis/IndexationPayload.tsx
@@ -20,35 +20,21 @@ class IndexationPayload extends Component<IndexationPayloadProps, IndexationPayl
      */
     constructor(props: IndexationPayloadProps) {
         super(props);
+        // this.state = {
+        //     utf8Index: undefined,
+        //     hexIndex: "0",
+        //     utf8Data: undefined,
+        //     hexData: undefined,
+        //     jsonData: undefined
+        // };
+        this.loadPayload();
+        console.log("constructor de indexation apyload")
+    }
 
-        const utf8Index = TextHelper.isUTF8(Converter.hexToBytes(props.payload.index)) ? Converter.hexToUtf8(props.payload.index) : undefined;
-        const matchHexIndex = props.payload.index.match(/.{1,2}/g);
-        const hexIndex = matchHexIndex ? matchHexIndex.join(" ") : props.payload.index;
-
-        let hexData;
-        let utf8Data;
-        let jsonData;
-
-        if (props.payload.data) {
-            const matchHexData = props.payload.data.match(/.{1,2}/g);
-
-            hexData = matchHexData ? matchHexData.join(" ") : props.payload.data;
-            utf8Data = TextHelper.isUTF8(Converter.hexToBytes(props.payload.data)) ? Converter.hexToUtf8(props.payload.data) : undefined;
-
-            try {
-                if (utf8Data) {
-                    jsonData = JSON.stringify(JSON.parse(utf8Data), undefined, "  ");
-                }
-            } catch { }
+    public componentDidUpdate(prevProps: IndexationPayloadProps): void {
+        if (prevProps.payload !== this.props.payload) {
+            this.loadPayload();
         }
-
-        this.state = {
-            utf8Index,
-            hexIndex,
-            utf8Data,
-            hexData,
-            jsonData
-        };
     }
 
     /**
@@ -116,6 +102,37 @@ class IndexationPayload extends Component<IndexationPayloadProps, IndexationPayl
                 </div>
             </div>
         );
+    }
+
+    private loadPayload() {
+        const utf8Index = TextHelper.isUTF8(Converter.hexToBytes(this.props.payload.index)) ? Converter.hexToUtf8(this.props.payload.index) : undefined;
+        const matchHexIndex = this.props.payload.index.match(/.{1,2}/g);
+        const hexIndex = matchHexIndex ? matchHexIndex.join(" ") : this.props.payload.index;
+
+        let hexData;
+        let utf8Data;
+        let jsonData;
+
+        if (this.props.payload.data) {
+            const matchHexData = this.props.payload.data.match(/.{1,2}/g);
+
+            hexData = matchHexData ? matchHexData.join(" ") : this.props.payload.data;
+            utf8Data = TextHelper.isUTF8(Converter.hexToBytes(this.props.payload.data)) ? Converter.hexToUtf8(this.props.payload.data) : undefined;
+
+            try {
+                if (utf8Data) {
+                    jsonData = JSON.stringify(JSON.parse(utf8Data), undefined, "  ");
+                }
+            } catch { }
+        }
+
+        this.setState({
+            utf8Index,
+            hexIndex,
+            utf8Data,
+            hexData,
+            jsonData
+        });
     }
 }
 

--- a/client/src/app/components/chrysalis/IndexationPayload.tsx
+++ b/client/src/app/components/chrysalis/IndexationPayload.tsx
@@ -21,7 +21,6 @@ class IndexationPayload extends Component<IndexationPayloadProps, IndexationPayl
     constructor(props: IndexationPayloadProps) {
         super(props);
         this.state = this.loadPayload();
-        console.log("constructor de indexation apyload")
     }
 
     public componentDidUpdate(prevProps: IndexationPayloadProps): void {

--- a/client/src/app/components/chrysalis/IndexationPayload.tsx
+++ b/client/src/app/components/chrysalis/IndexationPayload.tsx
@@ -20,20 +20,13 @@ class IndexationPayload extends Component<IndexationPayloadProps, IndexationPayl
      */
     constructor(props: IndexationPayloadProps) {
         super(props);
-        // this.state = {
-        //     utf8Index: undefined,
-        //     hexIndex: "0",
-        //     utf8Data: undefined,
-        //     hexData: undefined,
-        //     jsonData: undefined
-        // };
-        this.loadPayload();
+        this.state = this.loadPayload();
         console.log("constructor de indexation apyload")
     }
 
     public componentDidUpdate(prevProps: IndexationPayloadProps): void {
         if (prevProps.payload !== this.props.payload) {
-            this.loadPayload();
+            this.setState(this.loadPayload());
         }
     }
 
@@ -104,6 +97,10 @@ class IndexationPayload extends Component<IndexationPayloadProps, IndexationPayl
         );
     }
 
+    /**
+     * Load index and data from payload.
+     * @returns Object with indexes and data in raw and utf-8 format.
+     */
     private loadPayload() {
         const utf8Index = TextHelper.isUTF8(Converter.hexToBytes(this.props.payload.index)) ? Converter.hexToUtf8(this.props.payload.index) : undefined;
         const matchHexIndex = this.props.payload.index.match(/.{1,2}/g);
@@ -125,14 +122,13 @@ class IndexationPayload extends Component<IndexationPayloadProps, IndexationPayl
                 }
             } catch { }
         }
-
-        this.setState({
+        return {
             utf8Index,
             hexIndex,
             utf8Data,
             hexData,
             jsonData
-        });
+        };
     }
 }
 

--- a/client/src/app/routes/chrysalis/Message.scss
+++ b/client/src/app/routes/chrysalis/Message.scss
@@ -1,7 +1,7 @@
-@import '../../../scss/fonts';
-@import '../../../scss/mixins';
-@import '../../../scss/media-queries';
-@import '../../../scss/variables';
+@import "../../../scss/fonts";
+@import "../../../scss/mixins";
+@import "../../../scss/media-queries";
+@import "../../../scss/variables";
 
 .message {
   display: flex;

--- a/client/src/app/routes/chrysalis/Message.tsx
+++ b/client/src/app/routes/chrysalis/Message.tsx
@@ -1,6 +1,6 @@
 import { CONFLICT_REASON_STRINGS, IMessageMetadata, INDEXATION_PAYLOAD_TYPE, MILESTONE_PAYLOAD_TYPE, TRANSACTION_PAYLOAD_TYPE, UnitsHelper } from "@iota/iota.js";
 import React, { ReactNode } from "react";
-import { Link, RouteComponentProps } from "react-router-dom";
+import { RouteComponentProps } from "react-router-dom";
 import { ServiceFactory } from "../../../factories/serviceFactory";
 import { ClipboardHelper } from "../../../helpers/clipboardHelper";
 import { MessageTangleStatus } from "../../../models/messageTangleStatus";
@@ -440,8 +440,6 @@ class Message extends AsyncComponent<RouteComponentProps<MessageRouteProps>, Mes
                     behavior: "smooth"
                 });
             }
-
-
 
             const { inputs, outputs, unlockAddresses, transferTotal } =
                 await TransactionsHelper.getInputsAndOutputs(result?.message,

--- a/client/src/app/routes/chrysalis/Message.tsx
+++ b/client/src/app/routes/chrysalis/Message.tsx
@@ -339,11 +339,13 @@ class Message extends AsyncComponent<RouteComponentProps<MessageRouteProps>, Mes
                         )}
                         <div className="section">
                             <div className="section--header">
-                                <div className="row middle">
-                                    <h2>
-                                        Messages tree (in progress 🚧)
-                                    </h2>
-                                    <Modal icon={ModalIcon.Info} data={messageJSON} />
+                                <div>
+                                    <div className="row middle">
+                                        <h2>
+                                            Messages tree
+                                        </h2>
+                                        <Modal icon={ModalIcon.Info} data={messageJSON} />
+                                    </div>
                                 </div>
                             </div>
                             {this.state.message?.parentMessageIds && this.state.childrenIds && (

--- a/client/src/app/routes/chrysalis/Message.tsx
+++ b/client/src/app/routes/chrysalis/Message.tsx
@@ -341,7 +341,7 @@ class Message extends AsyncComponent<RouteComponentProps<MessageRouteProps>, Mes
                             <div className="section--header">
                                 <div className="row middle">
                                     <h2>
-                                        Messages tree
+                                        Messages tree (in progress 🚧)
                                     </h2>
                                     <Modal icon={ModalIcon.Info} data={messageJSON} />
                                 </div>

--- a/client/src/app/routes/chrysalis/Message.tsx
+++ b/client/src/app/routes/chrysalis/Message.tsx
@@ -441,8 +441,7 @@ class Message extends AsyncComponent<RouteComponentProps<MessageRouteProps>, Mes
                 });
             }
 
-            window.history.replaceState(undefined, window.document.title, `/${this.props.match.params.network
-                }/message/${result.includedMessageId ?? messageId}`);
+
 
             const { inputs, outputs, unlockAddresses, transferTotal } =
                 await TransactionsHelper.getInputsAndOutputs(result?.message,
@@ -464,11 +463,8 @@ class Message extends AsyncComponent<RouteComponentProps<MessageRouteProps>, Mes
                 await this.updateMessageDetails();
             });
             if (updateUrl) {
-                window.history.replaceState(
-                    undefined,
-                    window.document.title,
-                    `/${this.props.match.params.network
-                    }/message/${messageId}`);
+                window.history.pushState(undefined, window.document.title, `/${this.props.match.params.network
+                    }/message/${result.includedMessageId ?? messageId}`);
             }
         } else {
             this.props.history.replace(`/${this.props.match.params.network

--- a/client/src/app/routes/chrysalis/Message.tsx
+++ b/client/src/app/routes/chrysalis/Message.tsx
@@ -16,6 +16,7 @@ import FiatValue from "../../components/FiatValue";
 import InclusionState from "../../components/InclusionState";
 import MessageButton from "../../components/MessageButton";
 import MessageTangleState from "../../components/MessageTangleState";
+import MessageTree from "../../components/MessageTree";
 import Modal from "../../components/Modal";
 import { ModalIcon } from "../../components/ModalProps";
 import Spinner from "../../components/Spinner";
@@ -345,101 +346,14 @@ class Message extends AsyncComponent<RouteComponentProps<MessageRouteProps>, Mes
                                     <Modal icon={ModalIcon.Info} data={messageJSON} />
                                 </div>
                             </div>
-                            <div className="section--data">
-                                <div className="section--header">
-                                    <h3>Parent Messages</h3>
-                                    {this.state !== undefined && (
-                                        <span className="messages--number">
-                                            {this.state.message?.parentMessageIds?.length}
-                                        </span>
-                                    )}
-                                </div>
-                                <div className="section--data">
-                                    {this.state.message?.parentMessageIds?.map((parent, idx) => (
-                                        <React.Fragment key={idx}>
-                                            <div
-                                                className="value code highlight
-                                                           row middle"
-                                            >
-                                                {parent !== "0".repeat(64) && (
-                                                    <React.Fragment>
-                                                        <button
-                                                            type="button"
-                                                            className="margin-r-t"
-                                                            onClick={
-                                                                async () =>
-                                                                    this.loadMessage(parent, true)
-                                                            }
-                                                        >
-                                                            {parent}
-                                                        </button>
-                                                        {/* <Link
-                                                            className="margin-r-t"
-                                                            to={
-                                                                `/${this.props.match.params.network
-                                                                }/message/${parent}`
-                                                            }
-                                                        >
-                                                            {parent}
-                                                        </Link> */}
-                                                        <MessageButton
-                                                            onClick={() => ClipboardHelper.copy(
-                                                                parent
-                                                            )}
-                                                            buttonType="copy"
-                                                            labelPosition="top"
-                                                        />
-                                                    </React.Fragment>
-                                                )}
-                                                {parent === "0".repeat(64) && (
-                                                    <span>Genesis</span>
-                                                )}
-                                            </div>
-                                        </React.Fragment>
-                                    )
-                                    )}
-                                </div>
-                                <div className="section--header">
-                                    <h3>Child Messages</h3>
-                                    {this.state.childrenIds !== undefined && (
-                                        <span className="messages--number">
-                                            {this.state.childrenIds.length}
-                                        </span>
-                                    )}
-                                </div>
-                                <div className="section--data">
-                                    {this.state.childrenBusy && (<Spinner />)}
-                                    {this.state.childrenIds?.map(childId => (
-                                        <div
-                                            className="value
-                                                         code highlight row middle"
-                                            key={childId}
-                                        >
-                                            <Link
-                                                className="margin-r-t"
-                                                to={
-                                                    `/${this.props.match.params.network
-                                                    }/message/${childId}`
-                                                }
-                                            >
-                                                {childId}
-                                            </Link>
-                                            <MessageButton
-                                                onClick={() => ClipboardHelper.copy(
-                                                    childId
-                                                )}
-                                                buttonType="copy"
-                                                labelPosition="top"
-                                            />
-                                        </div>
-                                    ))}
-                                    {!this.state.childrenBusy &&
-                                        this.state.childrenIds &&
-                                        this.state.childrenIds.length === 0 && (
-                                            <p>There are no children for this message.</p>
-                                        )}
-                                </div>
-                            </div>
+                            {this.state.message?.parentMessageIds && this.state.childrenIds && (
+                                <MessageTree
+                                    parentsIds={this.state.message?.parentMessageIds}
+                                    messageId={this.props.match.params.messageId}
+                                    childrenIds={this.state.childrenIds}
+                                    onSelected={async (i, update) => this.loadMessage(i, update)}
+                                />
+                            )}
                         </div>
                     </div>
                 </div>
@@ -556,8 +470,6 @@ class Message extends AsyncComponent<RouteComponentProps<MessageRouteProps>, Mes
                     `/${this.props.match.params.network
                     }/message/${messageId}`);
             }
-            console.log(this.state.message?.payload?.type === INDEXATION_PAYLOAD_TYPE
-                ? this.state.message.payload : "no")
         } else {
             this.props.history.replace(`/${this.props.match.params.network
                 }/search/${messageId}`);

--- a/client/src/scss/themes.scss
+++ b/client/src/scss/themes.scss
@@ -26,6 +26,7 @@
   --did-color: #{$gray-7};
   --search-bg-opacity: 0.6;
   --card-color: #{$gray-6};
+  --message-tree-bg: #{$gray-2};
 
   body.darkmode {
     --body-background: #091326;
@@ -52,5 +53,6 @@
     --did-color: #{$gray-4};
     --search-bg-opacity: 0.2;
     --card-color: #{$gray-4};
+    --message-tree-bg: #ffffff1f;
   }
 }


### PR DESCRIPTION
# Description of change
This PR aims to add the Message tree tool that allows you to easily navigate between messages by clicking on parents or children and see how the Message page data changes without refreshing the page.

## Type of change
- Enhancement (a non-breaking change which adds functionality)
